### PR TITLE
Enable incremental runs with modified sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *_linux*/
 build_*/
 .idea*/*
+kernel_source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,28 @@
-FROM ubuntu:latest
-
+FROM ubuntu:latest AS build-deps
 RUN apt update
 RUN apt install -y build-essential \
-                    ncurses-dev \
-                    bc \
-                    git \
-                    libssl-dev \
-                    libc6-i386 \
-                    curl \
-                    libproc-processtable-perl \
-                    wget \
-                    kmod \
-                    jq \
-                    cifs-utils \
-                    python3 \
-                    python3-pip \
-                    python-is-python3
+    ncurses-dev \
+    bc \
+    git \
+    libssl-dev \
+    libc6-i386 \
+    curl \
+    libproc-processtable-perl \
+    wget \
+    kmod \
+    jq \
+    cifs-utils \
+    python3 \
+    python3-pip \
+    python-is-python3
 
-RUN mkdir /synology-toolkit
-RUN mkdir /synology-toolkit/toolchains
-
+FROM build-deps AS cross-deps
+ARG PLATFORM
+ENV PLATFORM=$PLATFORM
+RUN mkdir -p /synology-toolkit /synology-toolkit/toolchains
 WORKDIR /synology-toolkit
-COPY platforms.json .
-COPY entrypoint.sh .
-COPY config_modification.json .
+COPY platforms.json install.sh ./
+RUN ./install.sh
 
-ENV PLATFORM=""
-
+COPY entrypoint.sh config_modification.json ./
 ENTRYPOINT ["/synology-toolkit/entrypoint.sh"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t compile_modules --build-arg PLATFORM=$1 .

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Check for platform ENV variable
+if [ -z "$PLATFORM" ]; then
+  echo "Error: PLATFORM is not set!"
+  echo "Use one of the following platforms:"
+  echo
+  jq -r 'keys[]' platforms.json
+  exit 1
+fi
+
+# Check for platforms file
+if [ ! -f "platforms.json" ]; then
+  echo "Error: platforms.json not found!"
+  exit 1
+fi
+
+echo "PLATFORM is set to: $PLATFORM"
+
+# read all the values from the platforms file.
+export $(jq -r --arg PLATFORM "$PLATFORM" '.[$PLATFORM] | to_entries | map("SYNO_\(.key)=\(.value)") | .[]' platforms.json)
+
+#------------------------------------------------------
+
+echo
+echo "Setup toolkit..."
+echo
+git clone https://github.com/SynologyOpenSource/pkgscripts-ng
+cd pkgscripts-ng
+git checkout DSM7.2
+./EnvDeploy -v 7.2 -p $PLATFORM
+cd ..
+
+#------------------------------------------------------
+
+echo
+echo "Downloads..."
+echo
+#download toolkit
+echo "Downloading toolchain for $PLATFORM"
+toolchain_fn=$(basename "$SYNO_toolchain")
+curl --progress-bar -L -o "$toolchain_fn" "$SYNO_toolchain"
+toolchain_folder=$(tar -Jtf "${toolchain_fn}" | cut -d/ -f1 | uniq | head -n 1)
+echo "Downloaded toolchain: $toolchain_fn"
+echo "Archive top-level folder name: $toolchain_folder"
+
+#------------------------------------------------------
+
+echo
+echo "Installs..."
+echo
+# install toolchain
+tar -Jxvf ./${toolchain_fn} -C /usr/local/
+echo "/usr/local/$toolchain_folder" > /toolchain_folder

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+docker run --privileged --rm \
+    -v ./kernel_source:/kernel_source:rw \
+    -v ./compiled_modules:/compiled_modules:rw \
+    compile_modules


### PR DESCRIPTION
I am interested in compiling modified versions of the kernel modules, but some changes to the Docker solution are needed. Previously, it would download and build the original source on each run.

This PR makes it so you can bind mount a directory containing kernel sources. If the directory is empty, the sources are downloaded just as before. If files already exist, they are ignored. This allows you to make (limited) changes to the source files and then run the container again to compile your modifications.

Additionally, I pushed installation of the toolkit from the container layer up to the image layer, since the toolkit never changes between runs, it can be part of the image.

Usage is now slightly different, you specify `PLATFORM` for the build, not when running:

``` sh
# Build an image with the apollolake toolkit
docker build -t compile_modules --build-arg PLATFORM=apollolake

# Run the image without specifying PLATFORM
# Optionally, you can bind mount /kernel_source
docker run --privileged --rm \
    -v ./kernel_source:/kernel_source:rw \
    -v ./compiled_modules:/compiled_modules:rw \
    compile_modules
```

Helper `build.sh` and `run.sh` scripts are provided so you don't have to remember the above.

``` sh
./build.sh apollolake
./run.sh
```