### PR TITLE
Make scripts executable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY platforms.json .
 COPY entrypoint.sh .
 COPY config_modification.json .
 COPY apply_patches.sh .
+RUN chmod +x apply_patches.sh entrypoint.sh
 
 ENV PLATFORM=""
 


### PR DESCRIPTION
This fixes a permission denied error I got when trying to run the container


> `docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/synology-toolkit/entrypoint.sh": permission denied`

PS: Thanks for this! I was able to use this to compile the AppleTalk module to get my Synology to run [Netatalk](https://github.com/Netatalk/netatalk)